### PR TITLE
gotooltest: support the go command in script tests

### DIFF
--- a/goproxytest/proxy.go
+++ b/goproxytest/proxy.go
@@ -61,6 +61,8 @@ type Server struct {
 // network address. It serves modules taken from the given directory
 // name. If addr is empty, it will listen on an arbitrary
 // localhost port. If dir is empty, "testmod" will be used.
+//
+// The returned Server should be closed after use.
 func NewServer(dir, addr string) (*Server, error) {
 	var srv Server
 	if addr == "" {
@@ -83,6 +85,11 @@ func NewServer(dir, addr string) (*Server, error) {
 		log.Printf("go proxy: http.Serve: %v", http.Serve(l, http.HandlerFunc(srv.handler)))
 	}()
 	return &srv, nil
+}
+
+// Close shuts down the proxy.
+func (srv *Server) Close() {
+	srv.listener.Close()
 }
 
 func (srv *Server) readModList() error {

--- a/gotooltest/setup.go
+++ b/gotooltest/setup.go
@@ -1,0 +1,137 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package gotooltest implements functionality useful for testing
+// tools that use the go command.
+package gotooltest
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/rogpeppe/modinternal/imports"
+	"github.com/rogpeppe/modinternal/testscript"
+)
+
+type testContext struct {
+	goroot  string
+	gocache string
+}
+
+// Setup sets up the given test environment for tests that use the go
+// command. It adds support for go tags to p.Condition and adds the go
+// command to p.Cmds. It also wraps p.Setup to set up the environment
+// variables for running the go command appropriately.
+//
+// It checks go command can run, but not that it can build or run
+// binaries.
+func Setup(p *testscript.Params) error {
+	var c testContext
+	if err := c.init(); err != nil {
+		return err
+	}
+	origSetup := p.Setup
+	p.Setup = func(e *testscript.Env) error {
+		e.Vars = c.goEnviron(e.Vars)
+		return origSetup(e)
+	}
+	if p.Cmds == nil {
+		p.Cmds = make(map[string]func(ts *testscript.TestScript, neg bool, args []string))
+	}
+	p.Cmds["go"] = cmdGo
+	origCondition := p.Condition
+	p.Condition = func(cond string) (bool, error) {
+		switch cond {
+		case runtime.GOOS, runtime.GOARCH, runtime.Compiler:
+			return true, nil
+		default:
+			if imports.KnownArch[cond] || imports.KnownOS[cond] || cond == "gc" || cond == "gccgo" {
+				return false, nil
+			}
+		}
+		if origCondition == nil {
+			return false, fmt.Errorf("unknown condition %q", cond)
+		}
+		return origCondition(cond)
+	}
+	return nil
+}
+
+func (c *testContext) init() error {
+	goEnv := func(name string) (string, error) {
+		out, err := exec.Command("go", "env", name).CombinedOutput()
+		if err != nil {
+			return "", fmt.Errorf("go env %s: %v (%s)", name, err, out)
+		}
+		return strings.TrimSpace(string(out)), nil
+	}
+	var err error
+	c.goroot, err = goEnv("GOROOT")
+	if err != nil {
+		return err
+	}
+	c.gocache, err = goEnv("GOCACHE")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *testContext) goEnviron(env0 []string) []string {
+	env := environ(env0)
+	workdir := env.get("WORK")
+	return append(env, []string{
+		"GOPATH=" + filepath.Join(workdir, "gopath"),
+		"CCACHE_DISABLE=1", // ccache breaks with non-existent HOME
+		"GOARCH=" + runtime.GOARCH,
+		"GOOS=" + runtime.GOOS,
+		"GOROOT=" + c.goroot,
+		"GOCACHE=" + c.gocache,
+	}...)
+}
+
+func cmdGo(ts *testscript.TestScript, neg bool, args []string) {
+	if len(args) < 1 {
+		ts.Fatalf("usage: go subcommand ...")
+	}
+	err := ts.Exec("go", args...)
+	if err != nil {
+		ts.Logf("[%v]\n", err)
+		if !neg {
+			ts.Fatalf("unexpected go command failure")
+		}
+	} else {
+		if neg {
+			ts.Fatalf("unexpected go command success")
+		}
+	}
+}
+
+type environ []string
+
+func (e0 *environ) get(name string) string {
+	e := *e0
+	for i := len(e) - 1; i >= 0; i-- {
+		v := e[i]
+		if len(v) <= len(name) {
+			continue
+		}
+		if strings.HasPrefix(v, name) && v[len(name)] == '=' {
+			return v[len(name)+1:]
+		}
+	}
+	return ""
+}
+
+func (e *environ) set(name, val string) {
+	*e = append(*e, name+"="+val)
+}
+
+func (e *environ) unset(name string) {
+	// TODO actually remove the name from the environment.
+	e.set(name, "")
+}

--- a/imports/build.go
+++ b/imports/build.go
@@ -1,0 +1,211 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Copied from Go distribution src/go/build/build.go, syslist.go
+
+package imports
+
+import (
+	"bytes"
+	"strings"
+	"unicode"
+)
+
+var slashslash = []byte("//")
+
+// ShouldBuild reports whether it is okay to use this file,
+// The rule is that in the file's leading run of // comments
+// and blank lines, which must be followed by a blank line
+// (to avoid including a Go package clause doc comment),
+// lines beginning with '// +build' are taken as build directives.
+//
+// The file is accepted only if each such line lists something
+// matching the file. For example:
+//
+//	// +build windows linux
+//
+// marks the file as applicable only on Windows and Linux.
+//
+// If tags["*"] is true, then ShouldBuild will consider every
+// build tag except "ignore" to be both true and false for
+// the purpose of satisfying build tags, in order to estimate
+// (conservatively) whether a file could ever possibly be used
+// in any build.
+//
+func ShouldBuild(content []byte, tags map[string]bool) bool {
+	// Pass 1. Identify leading run of // comments and blank lines,
+	// which must be followed by a blank line.
+	end := 0
+	p := content
+	for len(p) > 0 {
+		line := p
+		if i := bytes.IndexByte(line, '\n'); i >= 0 {
+			line, p = line[:i], p[i+1:]
+		} else {
+			p = p[len(p):]
+		}
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 { // Blank line
+			end = len(content) - len(p)
+			continue
+		}
+		if !bytes.HasPrefix(line, slashslash) { // Not comment line
+			break
+		}
+	}
+	content = content[:end]
+
+	// Pass 2.  Process each line in the run.
+	p = content
+	allok := true
+	for len(p) > 0 {
+		line := p
+		if i := bytes.IndexByte(line, '\n'); i >= 0 {
+			line, p = line[:i], p[i+1:]
+		} else {
+			p = p[len(p):]
+		}
+		line = bytes.TrimSpace(line)
+		if !bytes.HasPrefix(line, slashslash) {
+			continue
+		}
+		line = bytes.TrimSpace(line[len(slashslash):])
+		if len(line) > 0 && line[0] == '+' {
+			// Looks like a comment +line.
+			f := strings.Fields(string(line))
+			if f[0] == "+build" {
+				ok := false
+				for _, tok := range f[1:] {
+					if matchTags(tok, tags) {
+						ok = true
+					}
+				}
+				if !ok {
+					allok = false
+				}
+			}
+		}
+	}
+
+	return allok
+}
+
+// matchTags reports whether the name is one of:
+//
+//	tag (if tags[tag] is true)
+//	!tag (if tags[tag] is false)
+//	a comma-separated list of any of these
+//
+func matchTags(name string, tags map[string]bool) bool {
+	if name == "" {
+		return false
+	}
+	if i := strings.Index(name, ","); i >= 0 {
+		// comma-separated list
+		ok1 := matchTags(name[:i], tags)
+		ok2 := matchTags(name[i+1:], tags)
+		return ok1 && ok2
+	}
+	if strings.HasPrefix(name, "!!") { // bad syntax, reject always
+		return false
+	}
+	if strings.HasPrefix(name, "!") { // negation
+		return len(name) > 1 && matchTag(name[1:], tags, false)
+	}
+	return matchTag(name, tags, true)
+}
+
+// matchTag reports whether the tag name is valid and satisfied by tags[name]==want.
+func matchTag(name string, tags map[string]bool, want bool) bool {
+	// Tags must be letters, digits, underscores or dots.
+	// Unlike in Go identifiers, all digits are fine (e.g., "386").
+	for _, c := range name {
+		if !unicode.IsLetter(c) && !unicode.IsDigit(c) && c != '_' && c != '.' {
+			return false
+		}
+	}
+
+	if tags["*"] && name != "" && name != "ignore" {
+		// Special case for gathering all possible imports:
+		// if we put * in the tags map then all tags
+		// except "ignore" are considered both present and not
+		// (so we return true no matter how 'want' is set).
+		return true
+	}
+
+	have := tags[name]
+	if name == "linux" {
+		have = have || tags["android"]
+	}
+	return have == want
+}
+
+// MatchFile returns false if the name contains a $GOOS or $GOARCH
+// suffix which does not match the current system.
+// The recognized name formats are:
+//
+//     name_$(GOOS).*
+//     name_$(GOARCH).*
+//     name_$(GOOS)_$(GOARCH).*
+//     name_$(GOOS)_test.*
+//     name_$(GOARCH)_test.*
+//     name_$(GOOS)_$(GOARCH)_test.*
+//
+// An exception: if GOOS=android, then files with GOOS=linux are also matched.
+//
+// If tags["*"] is true, then MatchFile will consider all possible
+// GOOS and GOARCH to be available and will consequently
+// always return true.
+func MatchFile(name string, tags map[string]bool) bool {
+	if tags["*"] {
+		return true
+	}
+	if dot := strings.Index(name, "."); dot != -1 {
+		name = name[:dot]
+	}
+
+	// Before Go 1.4, a file called "linux.go" would be equivalent to having a
+	// build tag "linux" in that file. For Go 1.4 and beyond, we require this
+	// auto-tagging to apply only to files with a non-empty prefix, so
+	// "foo_linux.go" is tagged but "linux.go" is not. This allows new operating
+	// systems, such as android, to arrive without breaking existing code with
+	// innocuous source code in "android.go". The easiest fix: cut everything
+	// in the name before the initial _.
+	i := strings.Index(name, "_")
+	if i < 0 {
+		return true
+	}
+	name = name[i:] // ignore everything before first _
+
+	l := strings.Split(name, "_")
+	if n := len(l); n > 0 && l[n-1] == "test" {
+		l = l[:n-1]
+	}
+	n := len(l)
+	if n >= 2 && KnownOS[l[n-2]] && KnownArch[l[n-1]] {
+		return tags[l[n-2]] && tags[l[n-1]]
+	}
+	if n >= 1 && KnownOS[l[n-1]] {
+		return tags[l[n-1]]
+	}
+	if n >= 1 && KnownArch[l[n-1]] {
+		return tags[l[n-1]]
+	}
+	return true
+}
+
+var KnownOS = make(map[string]bool)
+var KnownArch = make(map[string]bool)
+
+func init() {
+	for _, v := range strings.Fields(goosList) {
+		KnownOS[v] = true
+	}
+	for _, v := range strings.Fields(goarchList) {
+		KnownArch[v] = true
+	}
+}
+
+const goosList = "android darwin dragonfly freebsd js linux nacl netbsd openbsd plan9 solaris windows zos "
+const goarchList = "386 amd64 amd64p32 arm armbe arm64 arm64be ppc64 ppc64le mips mipsle mips64 mips64le mips64p32 mips64p32le ppc riscv riscv64 s390 s390x sparc sparc64 wasm "

--- a/imports/read.go
+++ b/imports/read.go
@@ -1,0 +1,249 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Copied from Go distribution src/go/build/read.go.
+
+package imports
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"unicode/utf8"
+)
+
+type importReader struct {
+	b    *bufio.Reader
+	buf  []byte
+	peek byte
+	err  error
+	eof  bool
+	nerr int
+}
+
+func isIdent(c byte) bool {
+	return 'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z' || '0' <= c && c <= '9' || c == '_' || c >= utf8.RuneSelf
+}
+
+var (
+	errSyntax = errors.New("syntax error")
+	errNUL    = errors.New("unexpected NUL in input")
+)
+
+// syntaxError records a syntax error, but only if an I/O error has not already been recorded.
+func (r *importReader) syntaxError() {
+	if r.err == nil {
+		r.err = errSyntax
+	}
+}
+
+// readByte reads the next byte from the input, saves it in buf, and returns it.
+// If an error occurs, readByte records the error in r.err and returns 0.
+func (r *importReader) readByte() byte {
+	c, err := r.b.ReadByte()
+	if err == nil {
+		r.buf = append(r.buf, c)
+		if c == 0 {
+			err = errNUL
+		}
+	}
+	if err != nil {
+		if err == io.EOF {
+			r.eof = true
+		} else if r.err == nil {
+			r.err = err
+		}
+		c = 0
+	}
+	return c
+}
+
+// peekByte returns the next byte from the input reader but does not advance beyond it.
+// If skipSpace is set, peekByte skips leading spaces and comments.
+func (r *importReader) peekByte(skipSpace bool) byte {
+	if r.err != nil {
+		if r.nerr++; r.nerr > 10000 {
+			panic("go/build: import reader looping")
+		}
+		return 0
+	}
+
+	// Use r.peek as first input byte.
+	// Don't just return r.peek here: it might have been left by peekByte(false)
+	// and this might be peekByte(true).
+	c := r.peek
+	if c == 0 {
+		c = r.readByte()
+	}
+	for r.err == nil && !r.eof {
+		if skipSpace {
+			// For the purposes of this reader, semicolons are never necessary to
+			// understand the input and are treated as spaces.
+			switch c {
+			case ' ', '\f', '\t', '\r', '\n', ';':
+				c = r.readByte()
+				continue
+
+			case '/':
+				c = r.readByte()
+				if c == '/' {
+					for c != '\n' && r.err == nil && !r.eof {
+						c = r.readByte()
+					}
+				} else if c == '*' {
+					var c1 byte
+					for (c != '*' || c1 != '/') && r.err == nil {
+						if r.eof {
+							r.syntaxError()
+						}
+						c, c1 = c1, r.readByte()
+					}
+				} else {
+					r.syntaxError()
+				}
+				c = r.readByte()
+				continue
+			}
+		}
+		break
+	}
+	r.peek = c
+	return r.peek
+}
+
+// nextByte is like peekByte but advances beyond the returned byte.
+func (r *importReader) nextByte(skipSpace bool) byte {
+	c := r.peekByte(skipSpace)
+	r.peek = 0
+	return c
+}
+
+// readKeyword reads the given keyword from the input.
+// If the keyword is not present, readKeyword records a syntax error.
+func (r *importReader) readKeyword(kw string) {
+	r.peekByte(true)
+	for i := 0; i < len(kw); i++ {
+		if r.nextByte(false) != kw[i] {
+			r.syntaxError()
+			return
+		}
+	}
+	if isIdent(r.peekByte(false)) {
+		r.syntaxError()
+	}
+}
+
+// readIdent reads an identifier from the input.
+// If an identifier is not present, readIdent records a syntax error.
+func (r *importReader) readIdent() {
+	c := r.peekByte(true)
+	if !isIdent(c) {
+		r.syntaxError()
+		return
+	}
+	for isIdent(r.peekByte(false)) {
+		r.peek = 0
+	}
+}
+
+// readString reads a quoted string literal from the input.
+// If an identifier is not present, readString records a syntax error.
+func (r *importReader) readString(save *[]string) {
+	switch r.nextByte(true) {
+	case '`':
+		start := len(r.buf) - 1
+		for r.err == nil {
+			if r.nextByte(false) == '`' {
+				if save != nil {
+					*save = append(*save, string(r.buf[start:]))
+				}
+				break
+			}
+			if r.eof {
+				r.syntaxError()
+			}
+		}
+	case '"':
+		start := len(r.buf) - 1
+		for r.err == nil {
+			c := r.nextByte(false)
+			if c == '"' {
+				if save != nil {
+					*save = append(*save, string(r.buf[start:]))
+				}
+				break
+			}
+			if r.eof || c == '\n' {
+				r.syntaxError()
+			}
+			if c == '\\' {
+				r.nextByte(false)
+			}
+		}
+	default:
+		r.syntaxError()
+	}
+}
+
+// readImport reads an import clause - optional identifier followed by quoted string -
+// from the input.
+func (r *importReader) readImport(imports *[]string) {
+	c := r.peekByte(true)
+	if c == '.' {
+		r.peek = 0
+	} else if isIdent(c) {
+		r.readIdent()
+	}
+	r.readString(imports)
+}
+
+// ReadComments is like ioutil.ReadAll, except that it only reads the leading
+// block of comments in the file.
+func ReadComments(f io.Reader) ([]byte, error) {
+	r := &importReader{b: bufio.NewReader(f)}
+	r.peekByte(true)
+	if r.err == nil && !r.eof {
+		// Didn't reach EOF, so must have found a non-space byte. Remove it.
+		r.buf = r.buf[:len(r.buf)-1]
+	}
+	return r.buf, r.err
+}
+
+// ReadImports is like ioutil.ReadAll, except that it expects a Go file as input
+// and stops reading the input once the imports have completed.
+func ReadImports(f io.Reader, reportSyntaxError bool, imports *[]string) ([]byte, error) {
+	r := &importReader{b: bufio.NewReader(f)}
+
+	r.readKeyword("package")
+	r.readIdent()
+	for r.peekByte(true) == 'i' {
+		r.readKeyword("import")
+		if r.peekByte(true) == '(' {
+			r.nextByte(false)
+			for r.peekByte(true) != ')' && r.err == nil {
+				r.readImport(imports)
+			}
+			r.nextByte(false)
+		} else {
+			r.readImport(imports)
+		}
+	}
+
+	// If we stopped successfully before EOF, we read a byte that told us we were done.
+	// Return all but that last byte, which would cause a syntax error if we let it through.
+	if r.err == nil && !r.eof {
+		return r.buf[:len(r.buf)-1], nil
+	}
+
+	// If we stopped for a syntax error, consume the whole file so that
+	// we are sure we don't change the errors that go/parser returns.
+	if r.err == errSyntax && !reportSyntaxError {
+		r.err = nil
+		for r.err == nil && !r.eof {
+			r.readByte()
+		}
+	}
+
+	return r.buf, r.err
+}

--- a/imports/read_test.go
+++ b/imports/read_test.go
@@ -1,0 +1,228 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Copied from Go distribution src/go/build/read.go.
+
+package imports
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+const quote = "`"
+
+type readTest struct {
+	// Test input contains ℙ where readImports should stop.
+	in  string
+	err string
+}
+
+var readImportsTests = []readTest{
+	{
+		`package p`,
+		"",
+	},
+	{
+		`package p; import "x"`,
+		"",
+	},
+	{
+		`package p; import . "x"`,
+		"",
+	},
+	{
+		`package p; import "x";ℙvar x = 1`,
+		"",
+	},
+	{
+		`package p
+		
+		// comment
+		
+		import "x"
+		import _ "x"
+		import a "x"
+		
+		/* comment */
+		
+		import (
+			"x" /* comment */
+			_ "x"
+			a "x" // comment
+			` + quote + `x` + quote + `
+			_ /*comment*/ ` + quote + `x` + quote + `
+			a ` + quote + `x` + quote + `
+		)
+		import (
+		)
+		import ()
+		import()import()import()
+		import();import();import()
+		
+		ℙvar x = 1
+		`,
+		"",
+	},
+}
+
+var readCommentsTests = []readTest{
+	{
+		`ℙpackage p`,
+		"",
+	},
+	{
+		`ℙpackage p; import "x"`,
+		"",
+	},
+	{
+		`ℙpackage p; import . "x"`,
+		"",
+	},
+	{
+		`// foo
+
+		/* bar */
+
+		/* quux */ // baz
+		
+		/*/ zot */
+
+		// asdf
+		ℙHello, world`,
+		"",
+	},
+}
+
+func testRead(t *testing.T, tests []readTest, read func(io.Reader) ([]byte, error)) {
+	for i, tt := range tests {
+		var in, testOut string
+		j := strings.Index(tt.in, "ℙ")
+		if j < 0 {
+			in = tt.in
+			testOut = tt.in
+		} else {
+			in = tt.in[:j] + tt.in[j+len("ℙ"):]
+			testOut = tt.in[:j]
+		}
+		r := strings.NewReader(in)
+		buf, err := read(r)
+		if err != nil {
+			if tt.err == "" {
+				t.Errorf("#%d: err=%q, expected success (%q)", i, err, string(buf))
+				continue
+			}
+			if !strings.Contains(err.Error(), tt.err) {
+				t.Errorf("#%d: err=%q, expected %q", i, err, tt.err)
+				continue
+			}
+			continue
+		}
+		if err == nil && tt.err != "" {
+			t.Errorf("#%d: success, expected %q", i, tt.err)
+			continue
+		}
+
+		out := string(buf)
+		if out != testOut {
+			t.Errorf("#%d: wrong output:\nhave %q\nwant %q\n", i, out, testOut)
+		}
+	}
+}
+
+func TestReadImports(t *testing.T) {
+	testRead(t, readImportsTests, func(r io.Reader) ([]byte, error) { return ReadImports(r, true, nil) })
+}
+
+func TestReadComments(t *testing.T) {
+	testRead(t, readCommentsTests, ReadComments)
+}
+
+var readFailuresTests = []readTest{
+	{
+		`package`,
+		"syntax error",
+	},
+	{
+		"package p\n\x00\nimport `math`\n",
+		"unexpected NUL in input",
+	},
+	{
+		`package p; import`,
+		"syntax error",
+	},
+	{
+		`package p; import "`,
+		"syntax error",
+	},
+	{
+		"package p; import ` \n\n",
+		"syntax error",
+	},
+	{
+		`package p; import "x`,
+		"syntax error",
+	},
+	{
+		`package p; import _`,
+		"syntax error",
+	},
+	{
+		`package p; import _ "`,
+		"syntax error",
+	},
+	{
+		`package p; import _ "x`,
+		"syntax error",
+	},
+	{
+		`package p; import .`,
+		"syntax error",
+	},
+	{
+		`package p; import . "`,
+		"syntax error",
+	},
+	{
+		`package p; import . "x`,
+		"syntax error",
+	},
+	{
+		`package p; import (`,
+		"syntax error",
+	},
+	{
+		`package p; import ("`,
+		"syntax error",
+	},
+	{
+		`package p; import ("x`,
+		"syntax error",
+	},
+	{
+		`package p; import ("x"`,
+		"syntax error",
+	},
+}
+
+func TestReadFailures(t *testing.T) {
+	// Errors should be reported (true arg to readImports).
+	testRead(t, readFailuresTests, func(r io.Reader) ([]byte, error) { return ReadImports(r, true, nil) })
+}
+
+func TestReadFailuresIgnored(t *testing.T) {
+	// Syntax errors should not be reported (false arg to readImports).
+	// Instead, entire file should be the output and no error.
+	// Convert tests not to return syntax errors.
+	tests := make([]readTest, len(readFailuresTests))
+	copy(tests, readFailuresTests)
+	for i := range tests {
+		tt := &tests[i]
+		if !strings.Contains(tt.err, "NUL") {
+			tt.err = ""
+		}
+	}
+	testRead(t, tests, func(r io.Reader) ([]byte, error) { return ReadImports(r, false, nil) })
+}

--- a/imports/scan.go
+++ b/imports/scan.go
@@ -1,0 +1,96 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package imports
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+func ScanDir(dir string, tags map[string]bool) ([]string, []string, error) {
+	infos, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return nil, nil, err
+	}
+	var files []string
+	for _, info := range infos {
+		name := info.Name()
+		if info.Mode().IsRegular() && !strings.HasPrefix(name, "_") && strings.HasSuffix(name, ".go") && MatchFile(name, tags) {
+			files = append(files, filepath.Join(dir, name))
+		}
+	}
+	return scanFiles(files, tags, false)
+}
+
+func ScanFiles(files []string, tags map[string]bool) ([]string, []string, error) {
+	return scanFiles(files, tags, true)
+}
+
+func scanFiles(files []string, tags map[string]bool, explicitFiles bool) ([]string, []string, error) {
+	imports := make(map[string]bool)
+	testImports := make(map[string]bool)
+	numFiles := 0
+Files:
+	for _, name := range files {
+		r, err := os.Open(name)
+		if err != nil {
+			return nil, nil, err
+		}
+		var list []string
+		data, err := ReadImports(r, false, &list)
+		r.Close()
+		if err != nil {
+			return nil, nil, fmt.Errorf("reading %s: %v", name, err)
+		}
+
+		// import "C" is implicit requirement of cgo tag.
+		// When listing files on the command line (explicitFiles=true)
+		// we do not apply build tag filtering but we still do apply
+		// cgo filtering, so no explicitFiles check here.
+		// Why? Because we always have, and it's not worth breaking
+		// that behavior now.
+		for _, path := range list {
+			if path == `"C"` && !tags["cgo"] && !tags["*"] {
+				continue Files
+			}
+		}
+
+		if !explicitFiles && !ShouldBuild(data, tags) {
+			continue
+		}
+		numFiles++
+		m := imports
+		if strings.HasSuffix(name, "_test.go") {
+			m = testImports
+		}
+		for _, p := range list {
+			q, err := strconv.Unquote(p)
+			if err != nil {
+				continue
+			}
+			m[q] = true
+		}
+	}
+	if numFiles == 0 {
+		return nil, nil, ErrNoGo
+	}
+	return keys(imports), keys(testImports), nil
+}
+
+var ErrNoGo = fmt.Errorf("no Go source files")
+
+func keys(m map[string]bool) []string {
+	var list []string
+	for k := range m {
+		list = append(list, k)
+	}
+	sort.Strings(list)
+	return list
+}

--- a/imports/scan_test.go
+++ b/imports/scan_test.go
@@ -1,0 +1,68 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package imports
+
+import (
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+
+	"github.com/rogpeppe/modinternal/testenv"
+)
+
+func TestScan(t *testing.T) {
+	testenv.MustHaveGoBuild(t)
+
+	imports, testImports, err := ScanDir(filepath.Join(runtime.GOROOT(), "src/encoding/json"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundBase64 := false
+	for _, p := range imports {
+		if p == "encoding/base64" {
+			foundBase64 = true
+		}
+		if p == "encoding/binary" {
+			// A dependency but not an import
+			t.Errorf("json reported as importing encoding/binary but does not")
+		}
+		if p == "net/http" {
+			// A test import but not an import
+			t.Errorf("json reported as importing encoding/binary but does not")
+		}
+	}
+	if !foundBase64 {
+		t.Errorf("json missing import encoding/base64 (%q)", imports)
+	}
+
+	foundHTTP := false
+	for _, p := range testImports {
+		if p == "net/http" {
+			foundHTTP = true
+		}
+		if p == "unicode/utf16" {
+			// A package import but not a test import
+			t.Errorf("json reported as test-importing unicode/utf16  but does not")
+		}
+	}
+	if !foundHTTP {
+		t.Errorf("json missing test import net/http (%q)", testImports)
+	}
+}
+
+func TestScanStar(t *testing.T) {
+	testenv.MustHaveGoBuild(t)
+
+	imports, _, err := ScanDir("testdata/import1", map[string]bool{"*": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"import1", "import2", "import3", "import4"}
+	if !reflect.DeepEqual(imports, want) {
+		t.Errorf("ScanDir testdata/import1:\nhave %v\nwant %v", imports, want)
+	}
+}

--- a/imports/testdata/import1/x.go
+++ b/imports/testdata/import1/x.go
@@ -1,0 +1,3 @@
+package x
+
+import "import1"

--- a/imports/testdata/import1/x1.go
+++ b/imports/testdata/import1/x1.go
@@ -1,0 +1,9 @@
+// +build blahblh
+// +build linux
+// +build !linux
+// +build windows
+// +build darwin
+
+package x
+
+import "import4"

--- a/imports/testdata/import1/x_darwin.go
+++ b/imports/testdata/import1/x_darwin.go
@@ -1,0 +1,3 @@
+package xxxx
+
+import "import3"

--- a/imports/testdata/import1/x_windows.go
+++ b/imports/testdata/import1/x_windows.go
@@ -1,0 +1,3 @@
+package x
+
+import "import2"

--- a/testscript/cmd.go
+++ b/testscript/cmd.go
@@ -208,14 +208,7 @@ func (ts *TestScript) cmdExec(neg bool, args []string) {
 	if len(args) < 1 {
 		ts.Fatalf("usage: exec program [args...]")
 	}
-	var err error
-	ts.stdout, ts.stderr, err = ts.exec(args[0], args[1:]...)
-	if ts.stdout != "" {
-		ts.Logf("[stdout]\n%s", ts.stdout)
-	}
-	if ts.stderr != "" {
-		ts.Logf("[stderr]\n%s", ts.stderr)
-	}
+	err := ts.Exec(args[0], args[1:]...)
 	if err != nil {
 		ts.Logf("[%v]\n", err)
 		if !neg {


### PR DESCRIPTION
This package sets up the testscript parameters
to add support for the go command and related conditions.

I've removed support for running Go binaries because
there's quite a bit of complexity in the original there and I don't need
to do that yet.

This also needs the imports package to get the supported architectures
and OS's, so we pull that in too.